### PR TITLE
Import non-marker streams as events

### DIFF
--- a/eeg_load_xdf.m
+++ b/eeg_load_xdf.m
@@ -146,6 +146,30 @@ for s=1:length(streams)
             disp(['Could not interpret event stream named "' streams{s}.info.name '": ' err.message]);
         end
     end
+       % import makers from a non marker type of stream
+    if strcmp(streams{s}.info.type,'audio_onset')
+        try
+            %what characteristic of 
+            onset_Indices=find(streams{s}.time_series);
+            s_events = struct('type', '', 'latency', [], 'duration', num2cell(ones(1, length(onset_Indices))));
+            event_index=1;
+            for e=onset_Indices
+                if iscell(streams{s}.time_series)
+                    s_events(event_index).type = streams{s}.time_series{e};
+                else
+                    s_events(event_index).type = num2str(streams{s}.time_series(e));
+                end
+                [~, s_events(event_index).latency] = min(abs(stream.time_stamps - streams{s}.time_stamps(e)));
+                event_index=event_index+1;
+            end
+            event = [event, s_events]; %#ok<AGROW>
+            
+            
+        catch err
+            disp(['Problems reading AFEx data "' streams{s}.info.name '": ' err.message]);
+            
+        end
+    end
 end
 raw.event = event;
 

--- a/pop_loadxdf.m
+++ b/pop_loadxdf.m
@@ -73,12 +73,14 @@ if nargin < 1
 
 	% popup window parameters
 	% -----------------------
-    uigeom     = { [1 0.5] [1 0.5] [1 0.5] 0.13};
+    uigeom     = { [1 0.5] [1 0.5] [1 0.5] [1 0.5] 0.13};
     uilist   = { { 'style' 'text' 'string' 'Stream name to import:' } ...
                  { 'style' 'edit' 'string' '' } ...
                  { 'style' 'text' 'string' 'Stream type to import:' } ...
                  { 'style' 'edit' 'string' 'EEG' } ...
                  { 'style' 'text' 'string' 'Exclude marker streams(s):' } ...
+                 { 'style' 'edit' 'string' '{}' } ...
+                 { 'style' 'text' 'string' 'Stream name to import as event:' } ...
                  { 'style' 'edit' 'string' '{}' } {}};
 
 	result = inputgui(uigeom, uilist, 'pophelp(''pop_loadxdf'')', 'Load an XDF file');
@@ -93,6 +95,9 @@ if nargin < 1
         options = [options ', ''streamtype'', ''' result{2} '''']; end
     if ~isempty(result{3}),        
         options = [options ', ''exclude_markerstreams'', ' result{3} '']; end
+    if ~isempty(result{4}),        
+        options = [options ', ''stream_as_event'', ''' result{4} '''']; end
+    
 else
 	options = vararg2str(varargin);
 end;


### PR DESCRIPTION
So far it is only possible to import a stream of the type 'marker' as events. We have use cases where we want to use other streams as events. I extended the eeg_load_xdf.m and the pop_load_xdf, so that you can use any type of stream (just specify the name) as events. Currently, all non-zero entries of that stream are considered as event, all zero entries are dropped. 